### PR TITLE
Fix wrong URL in S3 HTML template

### DIFF
--- a/fastlane/lib/assets/s3_html_template.erb
+++ b/fastlane/lib/assets/s3_html_template.erb
@@ -54,7 +54,7 @@
 
     <div class="oneRow">
       <span class="download" id="ios">
-        <a href="itms-services://?action=download-manifest&url=itms-services://?action=download-manifest&url=<%= plist_url %>" id="text" class="btn btn-lg btn-default" onclick="document.getElementById('finished').id = '';">
+        <a href="itms-services://?action=download-manifest&url=<%= plist_url %>" id="text" class="btn btn-lg btn-default" onclick="document.getElementById('finished').id = '';">
           Install <%= title %> <%= bundle_version %>
         </a>
       </span>


### PR DESCRIPTION
Remove the duplicated `itms-services://?action=download-manifest&url=`